### PR TITLE
PHP 7 Compatibility

### DIFF
--- a/src/MicroQueue/Consumer.php
+++ b/src/MicroQueue/Consumer.php
@@ -38,7 +38,7 @@ final class Consumer
 
         if (false === $result) throw new Exception\MessageBufferSizeOverflowException;
 
-        if (self::CONSUMER_DEFAULT_MESSAGE_TYPE != $receivedMessageType) continue;
+        if (self::CONSUMER_DEFAULT_MESSAGE_TYPE != $receivedMessageType) return;
 
         call_user_func_array($callback, array($receivedMessage, $this->eventDispatcher));
     }


### PR DESCRIPTION
Replace the `continue` statement in order to avoid errors in the php version 7.x.

The error was:
`PHP Fatal error:  'continue' not in the 'loop' or 'switch' context in /tmp/microqueue/src/MicroQueue/Consumer.php on line 41`
